### PR TITLE
refactor: update repository annotations and clean up components

### DIFF
--- a/lib/domain/repositories/bank_account.dart
+++ b/lib/domain/repositories/bank_account.dart
@@ -10,7 +10,7 @@ import '../entities/account_extended.dart';
 import '../entities/error.dart';
 
 /// TODO: Заменить AccountHistoryResponse на entity
-@injectable
+@singleton
 abstract interface class BankAccountRepository {
   @factoryMethod
   factory BankAccountRepository(AccountsClient client) =>

--- a/lib/domain/repositories/categories.dart
+++ b/lib/domain/repositories/categories.dart
@@ -7,7 +7,7 @@ import '../../utils/either.dart';
 import '../entities/category.dart';
 import '../entities/error.dart';
 
-@injectable
+@singleton
 abstract interface class CategoriesRepository {
   @factoryMethod
   factory CategoriesRepository(CategoriesClient client) =>

--- a/lib/domain/repositories/transactions.dart
+++ b/lib/domain/repositories/transactions.dart
@@ -8,7 +8,7 @@ import '../entities/error.dart';
 import '../entities/transaction_extended.dart';
 import '../entities/transaction_short.dart';
 
-@injectable
+@singleton
 abstract interface class TransactionRepository {
   @factoryMethod
   factory TransactionRepository(TransactionsClient client) =>

--- a/lib/presentation/_components/action_row.dart
+++ b/lib/presentation/_components/action_row.dart
@@ -1,7 +1,7 @@
-part of '../components.dart';
+part of 'components.dart';
 
-class CommonSummaryHeaderCard extends StatelessWidget {
-  const CommonSummaryHeaderCard({
+class CommonHeaderCard extends StatelessWidget {
+  const CommonHeaderCard({
     super.key,
     required this.left,
     required this.right,

--- a/lib/presentation/_components/components.dart
+++ b/lib/presentation/_components/components.dart
@@ -8,8 +8,8 @@ import 'paints/icons/chevron_right.dart';
 
 part 'custom_circular_indicator.dart';
 part 'custom_divider.dart';
-part 'finance_summary/amount_card.dart';
-part 'finance_summary/finance_app_bar.dart';
+part 'action_row.dart';
+part 'finance_app_bar.dart';
 part 'finance_summary/finance_list_item.dart';
 part 'finance_summary/finance_list_item_wrapper.dart';
 part 'finance_summary/finance_list_view.dart';

--- a/lib/presentation/_components/finance_app_bar.dart
+++ b/lib/presentation/_components/finance_app_bar.dart
@@ -1,4 +1,4 @@
-part of '../components.dart';
+part of 'components.dart';
 
 class CommonFinanceAppBar extends StatelessWidget {
   const CommonFinanceAppBar({

--- a/lib/presentation/_components/finance_summary/sliver_amount_card.dart
+++ b/lib/presentation/_components/finance_summary/sliver_amount_card.dart
@@ -19,7 +19,7 @@ class CommonSummaryHeaderCardDelegate extends SliverPersistentHeaderDelegate {
   ) {
     return GestureDetector(
       onTap: onTap,
-      child: CommonSummaryHeaderCard(left: left, right: right),
+      child: CommonHeaderCard(left: left, right: right),
     );
   }
 

--- a/lib/presentation/_home/home.dart
+++ b/lib/presentation/_home/home.dart
@@ -3,8 +3,6 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_svg/svg.dart';
 
 import '../../di/injection.dart';
-import '../../domain/usecases/get_bank_accounts.dart';
-import '../../domain/usecases/get_categories.dart';
 import '../../utils/colors.dart';
 import '../../utils/icons.dart';
 import '../bank_account/bank_account.dart';

--- a/lib/presentation/_home/page.dart
+++ b/lib/presentation/_home/page.dart
@@ -19,12 +19,11 @@ class _HomePageState extends State<HomePage> {
           const SummaryTabNavigator(isExpense: true),
           const SummaryTabNavigator(isExpense: false),
           BlocProvider(
-            create: (context) =>
-                BankAccountCubit(getIt<GetBankAccountsUseCase>()),
+            create: (context) => getIt<BankAccountCubit>(),
             child: const BankAccountPage(),
           ),
           BlocProvider(
-            create: (context) => CategoriesCubit(getIt<GetCategoriesUseCase>()),
+            create: (context) => getIt<CategoriesCubit>(),
             child: const CategoriesPage(),
           ),
           const SettingsPage(),

--- a/lib/presentation/bank_account/logic/cubit.dart
+++ b/lib/presentation/bank_account/logic/cubit.dart
@@ -1,5 +1,6 @@
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:injectable/injectable.dart';
 
 import '../../../domain/entities/account_brief.dart';
 import '../../../domain/entities/status_page.dart';
@@ -7,6 +8,7 @@ import '../../../domain/usecases/get_bank_accounts.dart';
 
 part 'state.dart';
 
+@injectable
 class BankAccountCubit extends Cubit<BankAccountState> {
   BankAccountCubit(this._getBankAccountsUseCase)
       : super(const BankAccountState());

--- a/lib/presentation/bank_account/widgets/bank_account_edit_item.dart
+++ b/lib/presentation/bank_account/widgets/bank_account_edit_item.dart
@@ -19,7 +19,7 @@ class BankAccountEditItem extends StatelessWidget {
         child: Row(
           children: [
             Expanded(
-              child: CommonSummaryHeaderCard(
+              child: CommonHeaderCard(
                 left: bankAccount.name,
                 right: '${bankAccount.balance} ${bankAccount.currency}',
                 rightIcon: ChevronRight(color: appColors.chevronRight),

--- a/lib/presentation/bank_account/widgets/bank_acount_list_item.dart
+++ b/lib/presentation/bank_account/widgets/bank_acount_list_item.dart
@@ -13,14 +13,14 @@ class BankAccountListItem extends StatelessWidget {
     final appColors = Theme.of(context).extension<AppColors>()!;
     return Column(
       children: [
-        CommonSummaryHeaderCard(
+        CommonHeaderCard(
           leftIcon: const Icon(Icons.account_balance),
           left: bankAccount.name,
           right: '${bankAccount.balance} ${bankAccount.currency}',
           rightIcon: ChevronRight(color: appColors.chevronRight),
         ),
         const CustomDivider(),
-        CommonSummaryHeaderCard(
+        CommonHeaderCard(
           left: 'Валюта',
           right: bankAccount.currency,
           rightIcon: ChevronRight(color: appColors.chevronRight),

--- a/lib/presentation/categories/logic/cubit.dart
+++ b/lib/presentation/categories/logic/cubit.dart
@@ -1,6 +1,7 @@
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:fuzzy/fuzzy.dart';
+import 'package:injectable/injectable.dart';
 
 import '../../../domain/entities/category.dart';
 import '../../../domain/entities/status_page.dart';
@@ -8,6 +9,7 @@ import '../../../domain/usecases/get_categories.dart';
 
 part 'state.dart';
 
+@injectable
 class CategoriesCubit extends Cubit<CategoriesState> {
   CategoriesCubit(this._getCategoriesUseCase) : super(const CategoriesState());
 

--- a/lib/presentation/summary/logic/expense/cubit.dart
+++ b/lib/presentation/summary/logic/expense/cubit.dart
@@ -1,6 +1,9 @@
+import 'package:injectable/injectable.dart';
+
 import '../../../../domain/entities/transaction_extended.dart';
 import '../cubit.dart';
 
+@injectable
 class ExpenseSummaryCubit extends BaseSummaryCubit {
   ExpenseSummaryCubit(super.getTransactionsByPeriodUseCase);
 

--- a/lib/presentation/summary/logic/incomes/cubit.dart
+++ b/lib/presentation/summary/logic/incomes/cubit.dart
@@ -1,7 +1,10 @@
+import 'package:injectable/injectable.dart';
+
 import '../../../../domain/entities/transaction_extended.dart';
 
 import '../cubit.dart';
 
+@injectable
 class IncomesSummaryCubit extends BaseSummaryCubit {
   IncomesSummaryCubit(super.getTransactionsByPeriodUseCase);
 

--- a/lib/presentation/summary/summary_tab_navigator.dart
+++ b/lib/presentation/summary/summary_tab_navigator.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import '../../di/injection.dart';
-import '../../domain/usecases/transactions_by_period.dart';
 import '../history/history.dart';
 import 'logic/cubit.dart';
 import 'logic/expense/cubit.dart';
@@ -24,12 +23,8 @@ class SummaryTabNavigator<C extends BaseSummaryCubit> extends StatelessWidget {
           return MaterialPageRoute(
             builder: (context) => BlocProvider(
               create: (context) => isExpense
-                  ? ExpenseSummaryCubit(
-                      getIt<GetTransactionsByPeriodUseCase>(),
-                    )
-                  : IncomesSummaryCubit(
-                      getIt<GetTransactionsByPeriodUseCase>(),
-                    ),
+                  ? getIt<ExpenseSummaryCubit>()
+                  : getIt<IncomesSummaryCubit>(),
               child: HistoryPage<C>(),
             ),
           );
@@ -37,12 +32,8 @@ class SummaryTabNavigator<C extends BaseSummaryCubit> extends StatelessWidget {
         return MaterialPageRoute(
           builder: (context) => BlocProvider(
             create: (context) => isExpense
-                ? ExpenseSummaryCubit(
-                    getIt<GetTransactionsByPeriodUseCase>(),
-                  )
-                : IncomesSummaryCubit(
-                    getIt<GetTransactionsByPeriodUseCase>(),
-                  ),
+                ? getIt<ExpenseSummaryCubit>()
+                : getIt<IncomesSummaryCubit>(),
             child: SummaryPage<C>(
               title: isExpense ? 'Расходы сегодня' : 'Доходы сегодня',
               onSuffixPressed: () {


### PR DESCRIPTION
- Changed repository annotations from @injectable to @singleton for BankAccountRepository, CategoriesRepository, and TransactionRepository to ensure proper singleton behavior.
- Removed unused finance summary components (amount_card.dart and finance_app_bar.dart) to streamline the codebase.
- Updated references to CommonSummaryHeaderCard to CommonHeaderCard in various widgets for consistency.
- Simplified Cubit instantiation in home page and summary tab navigator by using getIt directly.